### PR TITLE
Fix improve server auth

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,4 +1,4 @@
-require("dotenv").config()
+require("dotenv").config();
 const createError = require("http-errors");
 const express = require("express");
 const path = require("path");
@@ -12,7 +12,7 @@ const questionsRoutes = require("./routes/api/v1/questions.js");
 const activitiesRoutes = require("./routes/api/v1/activities.js");
 const tokenRoutes = require("./routes/api/v1/token.js");
 const calculatorRoutes = require("./routes/api/v1/calculator.js");
-const { verifyAccessToken } = require("./middlewares/auth");
+const { authMiddleware } = require("./middlewares/auth");
 const app = express();
 
 app.use(cors());
@@ -21,7 +21,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, "public")));
-app.use(verifyAccessToken);
+app.use(authMiddleware);
 
 // api routes
 app.use("/api/v1", rootRoutes);

--- a/server/middlewares/auth.js
+++ b/server/middlewares/auth.js
@@ -1,39 +1,70 @@
 const jwt = require("jsonwebtoken");
+const error = require("../utils/error");
 
 const { ACCESS_TOKEN_SECRET } = process.env;
+
+const authStrictMiddleware = async (req, res, next) => {
+  const { authorization } = req.headers;
+
+  // if access token is missing deny the request
+  if (!authorization) {
+    req.user = null;
+    res
+      .status(401)
+      .json(
+        error(
+          401,
+          "The request has not been applied because it lacks valid authentication credentials for the target resource"
+        )
+      );
+    return;
+  }
+
+  const bearerToken = authorization.split(" ")[1];
+
+  await jwt.verify(bearerToken, ACCESS_TOKEN_SECRET, (err, decoded) => {
+    // if authentication is not valid deny the request
+    if (!decoded) {
+      req.user = null;
+      res
+        .status(401)
+        .json(
+          error(
+            401,
+            "The request has not been applied because it lacks valid authentication credentials for the target resource"
+          )
+        );
+      return;
+    }
+    // if authentication is valid set the user in the request
+    req.user = decoded;
+    next();
+  });
+};
 
 const authMiddleware = async (req, res, next) => {
   const { authorization } = req.headers;
 
+  // if access token exists
   if (authorization) {
-    const bearerToken = authorization.split(" ")[1];
+    // get the access token from bearer header
+    const accessToken = authorization.split(" ")[1];
 
-    await jwt.verify(bearerToken, ACCESS_TOKEN_SECRET, (err, decoded) => {
-      if (decoded) {
-        req.user = { data: decoded.data, accessToken: authorization };
+    // verify that the access token is valid and not exipred
+    await jwt.verify(accessToken, ACCESS_TOKEN_SECRET, (err, decoded) => {
+      // if the access token is not valid or expired unset the user and proceed to the next middleware
+      if (!decoded) {
+        req.user = null;
         next();
-      } else {
-        res.status(401).json({ message: "401 Unauthorized Access" });
+        return;
       }
-    });
-  } else {
-    res.status(401).json({ message: "401 Unauthorized Access" });
-  }
-};
 
-const verifyAccessToken = async (req, res, next) => {
-  const { authorization } = req.headers;
-
-  if (authorization) {
-    const bearerToken = authorization.split(" ")[1];
-
-    await jwt.verify(bearerToken, ACCESS_TOKEN_SECRET, (err, decoded) => {
-      if (decoded) {
-        req.user = { data: decoded.data, accessToken: authorization };
-      }
+      // if the access token is valid send it through the request to the next middleware
+      req.user = { ...decoded, accessToken: authorization };
     });
   }
+  // go to the next middleware
   next();
 };
 
-module.exports = { authMiddleware, verifyAccessToken };
+module.exports = { authStrictMiddleware, authMiddleware };

--- a/server/utils/error.js
+++ b/server/utils/error.js
@@ -1,0 +1,52 @@
+/**
+ * Description placeholder
+ * @date 4/21/2023 - 5:26:56 AM
+ *
+ * @param {number} status
+ * @param {string} message
+ */
+const error = (status, message) => {
+  switch (status) {
+    case 401:
+      return {
+        error: {
+          status: 401,
+          code: "Unauthorized",
+          message: message || "Unauthorized Access",
+          timestamp: new Date().toISOString(),
+        },
+      };
+    case 403:
+      return {
+        error: {
+          status: 403,
+          code: "Forbidden",
+          message,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    case 404:
+      return {
+        error: {
+          status: 404,
+          code: "Not Found",
+          message,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    case 409:
+      return {
+        error: {
+          status: 409,
+          code: "Conflict",
+          message,
+          timestamp: new Date().toISOString(),
+        },
+      };
+
+    default:
+      return {};
+  }
+};
+
+module.exports = error;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,41 @@
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 
 import Home from "./pages/Home";
 import LoginPage from "./pages/LoginPage";
 import SignUpPage from "./pages/SignUpPage";
 import TestResultPage from "./pages/TestResultPage";
 import { Test } from "./components/Test/Test";
-import { useUser } from "./hooks/useUser";
-import { useEffect } from "react"
 import AuthRoute from "./components/common/AuthRoute";
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Home />} />
-      <Route path="/login" element={<AuthRoute inverted><LoginPage /></AuthRoute>} /> 
-      <Route path="/signup" element={<AuthRoute inverted><SignUpPage /></AuthRoute>} />
+      <Route
+        path="/login"
+        element={
+          <AuthRoute inverted>
+            <LoginPage />
+          </AuthRoute>
+        }
+      />
+      <Route
+        path="/signup"
+        element={
+          <AuthRoute inverted>
+            <SignUpPage />
+          </AuthRoute>
+        }
+      />
       <Route path="/test-result" element={<TestResultPage />} />
-      <Route path="/test" element={<AuthRoute inverted><Test /></AuthRoute>} />
+      <Route
+        path="/test"
+        element={
+          <AuthRoute inverted>
+            <Test />
+          </AuthRoute>
+        }
+      />
     </Routes>
   );
 }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,8 +2,10 @@ import { useState } from "react";
 
 interface AuthResponse {
   success: boolean;
-  message?: string;
-  accessToken?: string;
+  message: string;
+  accessToken: string;
+  iat: number;
+  exp: number;
 }
 
 export default function useAuth() {
@@ -21,9 +23,11 @@ export default function useAuth() {
       }
     );
     const data: AuthResponse = await res.json();
+    const dat = new Date(data.exp * 1000).toUTCString();
+    console.log(dat);
     if (data && data.success) {
       setAuthenticated(true);
-      document.cookie = `jwt=${data.accessToken};`;
+      document.cookie = `jwt=${data.accessToken};expires=${dat};secure;sameSite=Strict;path=/;`;
       return { success: true };
     } else {
       setAuthenticated(false);

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -2,19 +2,21 @@ import { useDispatch, useSelector } from "react-redux";
 import { getCookie } from "../utils/cookie";
 import { add } from "../store/slices/userSlice";
 
-export function useUser(){
-    const dispatch = useDispatch()
-    const user = useSelector((state: any) => state.user)
+export function useUser() {
+  const dispatch = useDispatch();
+  const user = useSelector((state: any) => state.user);
 
-    async function setUser() {
-        const token = getCookie("jwt")
-        if (token){
-            const res = await fetch(process.env.REACT_APP_SERVER_URI + "/api/v1/auth/user", { headers: { "authorization": `Bearer ${token}` } })
-            const user = await res.json()
-            console.log(user)
-            dispatch(add(user))
-        }
+  async function setUser() {
+    const token = getCookie("jwt");
+    if (token) {
+      const res = await fetch(
+        process.env.REACT_APP_SERVER_URI + "/api/v1/auth/user",
+        { headers: { authorization: `Bearer ${token}` } }
+      );
+      const user = await res.json();
+      dispatch(add(user.data));
     }
+  }
 
-    return [user, setUser]
+  return [user, setUser];
 }


### PR DESCRIPTION
- **Improve error responses sent by the server in auth routes**

  **Examples:**
  ```json
  {
	  "success": false,
	  "error": {
		  "status": 401,
		  "code": "Unauthorized",
		  "message": "Password not valid",
		  "timestamp": "2023-04-21T10:32:13.986Z"
	  }
  }
  ```
  ```json
  {
	  "error": {
		  "status": 403,
		  "code": "Forbidden",
		  "message": "Cannot sign up while authenticated",
		  "timestamp": "2023-04-21T10:33:48.752Z"
	  }
  }
  ```

- **Add issued at and expiration of the authorization token in the response sent on successful login**
  ```json
   {
	  "success": true,
	  "message": "Authenticated successfully",
	  "accessToken": "access-token-here",
	  "iat": 1682073439,
	  "exp": 1682937439
  }
  ```